### PR TITLE
Lazily open file streams to prevent blocking on reads

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codedx/CodeDxPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/CodeDxPublisher.java
@@ -223,14 +223,8 @@ public class CodeDxPublisher extends Recorder implements SimpleBuildStep {
 
 
 		if (sourceAndBinaryZip != null) {
-
-			try {
-				buildOutput.println("Adding source/binary zip...");
-				toSend.put("Jenkins-SourceAndBinary", sourceAndBinaryZip.read());
-			} catch (IOException e) {
-				buildOutput.println("Failed to add source/binary zip.");
-			}
-
+			buildOutput.println("Adding source/binary zip...");
+			toSend.put("Jenkins-SourceAndBinary", new DeferredFilePathInputStream(sourceAndBinaryZip));
 		} else {
 			buildOutput.println("No matching source/binary files.");
 		}
@@ -242,12 +236,8 @@ public class CodeDxPublisher extends Recorder implements SimpleBuildStep {
 				FilePath path = workspace.child(file);
 
 				if (path.exists()) {
-					try {
-						buildOutput.println("Add tool output file " + path.getRemote() + " to request.");
-						toSend.put(path.getName(), path.read());
-					} catch (IOException e) {
-						buildOutput.println("Failed to add tool output file: " + path);
-					}
+					buildOutput.println("Add tool output file " + path.getRemote() + " to request.");
+					toSend.put(path.getName(), new DeferredFilePathInputStream(path));
 				} else {
 					buildOutput.println("Path specified but could not be found: " + path);
 				}

--- a/src/main/java/org/jenkinsci/plugins/codedx/DeferredFilePathInputStream.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/DeferredFilePathInputStream.java
@@ -1,0 +1,63 @@
+package org.jenkinsci.plugins.codedx;
+
+import hudson.FilePath;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DeferredFilePathInputStream extends InputStream {
+	FilePath fp;
+	InputStream is;
+
+	public DeferredFilePathInputStream(FilePath fp)
+	{
+		this.fp = fp;
+		this.is = null;
+	}
+
+	private void initStream() throws IOException {
+		if (this.is == null) {
+			try {
+				this.is = fp.read();
+			} catch (InterruptedException e) {
+				throw new IOException("Operation was interrupted", e);
+			}
+		}
+	}
+
+	@Override
+	public int read(byte[] b) throws IOException {
+		initStream();
+
+		int numRead = this.is.read(b);
+		if (numRead < b.length) {
+			this.is.close();
+		}
+
+		return numRead;
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		initStream();
+
+		int numRead = this.is.read(b, off, len);
+		if (numRead < len) {
+			this.is.close();
+		}
+
+		return numRead;
+	}
+
+	@Override
+	public int read() throws IOException {
+		initStream();
+
+		int result = this.is.read();
+		if (result < 0) {
+			this.is.close();
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
When a pipeline spans multiple nodes, it's possible for the Code Dx plugin to hang while uploading 2 or more files. It seems the channel used by Jenkins master node for agent operations may block if we leave a remote file stream open. This change defers reads until necessary, rather than opening and collecting them all at once.