### PR TITLE
Bugfix/refactor analysis fail config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
@@ -32,13 +32,11 @@ public class AnalysisResultConfiguration {
 	private int numBuildsInGraph;
 	private boolean breakForPolicy;
 
-	private BuildEffectBehavior analysisFailedBehavior;
-
 	@DataBoundConstructor
 	public AnalysisResultConfiguration(String failureSeverity,
 			String unstableSeverity, boolean failureOnlyNew,
 			boolean unstableOnlyNew, int numBuildsInGraph,
-			boolean breakForPolicy, BuildEffectBehavior analysisFailedBehavior) {
+			boolean breakForPolicy) {
 	
 		this.failureSeverity = failureSeverity;
 		this.unstableSeverity = unstableSeverity;
@@ -46,7 +44,6 @@ public class AnalysisResultConfiguration {
 		this.unstableOnlyNew = unstableOnlyNew;
 		this.numBuildsInGraph = numBuildsInGraph;
 		this.breakForPolicy = breakForPolicy;
-		this.analysisFailedBehavior = analysisFailedBehavior;
 	}
 	public String getFailureSeverity() {
 		return failureSeverity;
@@ -77,12 +74,6 @@ public class AnalysisResultConfiguration {
 	}
 	public void setNumBuildsInGraph(int numBuildsInGraph) {
 		this.numBuildsInGraph = numBuildsInGraph;
-	}
-	public BuildEffectBehavior getAnalysisFailedBehavior() {
-		return analysisFailedBehavior;
-	}
-	public void setAnalysisFailedBehavior(BuildEffectBehavior behavior) {
-		this.analysisFailedBehavior = behavior;
 	}
 	public boolean getBreakForPolicy() {
 		return breakForPolicy;

--- a/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
@@ -30,20 +30,20 @@ public class AnalysisResultConfiguration {
 	private boolean failureOnlyNew;
 	private boolean unstableOnlyNew;
 	private int numBuildsInGraph;
-	private boolean breakForPolicy;
+	private BuildEffectBehavior policyBreakBuildBehavior;
 
 	@DataBoundConstructor
 	public AnalysisResultConfiguration(String failureSeverity,
 			String unstableSeverity, boolean failureOnlyNew,
 			boolean unstableOnlyNew, int numBuildsInGraph,
-			boolean breakForPolicy) {
+			BuildEffectBehavior policyBreakBuildBehavior) {
 	
 		this.failureSeverity = failureSeverity;
 		this.unstableSeverity = unstableSeverity;
 		this.failureOnlyNew = failureOnlyNew;
 		this.unstableOnlyNew = unstableOnlyNew;
 		this.numBuildsInGraph = numBuildsInGraph;
-		this.breakForPolicy = breakForPolicy;
+		this.policyBreakBuildBehavior = policyBreakBuildBehavior;
 	}
 	public String getFailureSeverity() {
 		return failureSeverity;
@@ -75,10 +75,10 @@ public class AnalysisResultConfiguration {
 	public void setNumBuildsInGraph(int numBuildsInGraph) {
 		this.numBuildsInGraph = numBuildsInGraph;
 	}
-	public boolean getBreakForPolicy() {
-		return breakForPolicy;
+	public BuildEffectBehavior getPolicyBreakBuildBehavior() {
+		return policyBreakBuildBehavior;
 	}
-	public void setBreakForPolicy(boolean breakForPolicy) {
-		this.breakForPolicy = breakForPolicy;
+	public void setPolicyBreakBuildBehavior(BuildEffectBehavior behavior) {
+		policyBreakBuildBehavior = behavior;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/AnalysisResultConfiguration.java
@@ -14,6 +14,7 @@
  */
 package org.jenkinsci.plugins.codedx;
 
+import hudson.model.Build;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -29,22 +30,23 @@ public class AnalysisResultConfiguration {
 	private boolean failureOnlyNew;
 	private boolean unstableOnlyNew;
 	private int numBuildsInGraph;
-	private boolean breakIfFailed;
 	private boolean breakForPolicy;
+
+	private BuildEffectBehavior analysisFailedBehavior;
 
 	@DataBoundConstructor
 	public AnalysisResultConfiguration(String failureSeverity,
 			String unstableSeverity, boolean failureOnlyNew,
 			boolean unstableOnlyNew, int numBuildsInGraph,
-			boolean breakIfFailed, boolean breakForPolicy) {
+			boolean breakForPolicy, BuildEffectBehavior analysisFailedBehavior) {
 	
 		this.failureSeverity = failureSeverity;
 		this.unstableSeverity = unstableSeverity;
 		this.failureOnlyNew = failureOnlyNew;
 		this.unstableOnlyNew = unstableOnlyNew;
 		this.numBuildsInGraph = numBuildsInGraph;
-		this.breakIfFailed = breakIfFailed;
 		this.breakForPolicy = breakForPolicy;
+		this.analysisFailedBehavior = analysisFailedBehavior;
 	}
 	public String getFailureSeverity() {
 		return failureSeverity;
@@ -76,11 +78,11 @@ public class AnalysisResultConfiguration {
 	public void setNumBuildsInGraph(int numBuildsInGraph) {
 		this.numBuildsInGraph = numBuildsInGraph;
 	}
-	public boolean getBreakIfFailed() {
-		return breakIfFailed;
+	public BuildEffectBehavior getAnalysisFailedBehavior() {
+		return analysisFailedBehavior;
 	}
-	public void setBreakIfFailed(boolean breakIfFailed) {
-		this.breakIfFailed = breakIfFailed;
+	public void setAnalysisFailedBehavior(BuildEffectBehavior behavior) {
+		this.analysisFailedBehavior = behavior;
 	}
 	public boolean getBreakForPolicy() {
 		return breakForPolicy;

--- a/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.codedx;
 
 public enum BuildEffectBehavior {
-	MarkFailed("Mark Failed"),
-	MarkUnstable("Mark Unstable"),
-	None("Ignore");
+	MarkFailed("Mark Build as Failed"),
+	MarkUnstable("Mark Build as Unstable"),
+	None("Ignore Errors");
 
 	private String label;
 	BuildEffectBehavior(String label) {

--- a/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
@@ -1,16 +1,23 @@
 package org.jenkinsci.plugins.codedx;
 
+import hudson.model.Result;
+
 public enum BuildEffectBehavior {
-	MarkFailed("Mark Build as Failed"),
-	MarkUnstable("Mark Build as Unstable"),
-	None("Ignore Errors");
+	MarkFailed("Mark Build as Failed", Result.FAILURE),
+	MarkUnstable("Mark Build as Unstable", Result.UNSTABLE),
+	None("Ignore Errors", Result.SUCCESS);
 
 	private String label;
-	BuildEffectBehavior(String label) {
+	private Result equivalentResult;
+	BuildEffectBehavior(String label, Result equivalentResult) {
 		this.label = label;
+		this.equivalentResult = equivalentResult;
 	}
 
 	public String getLabel() {
 		return label;
+	}
+	public Result getEquivalentResult() {
+		return equivalentResult;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/BuildEffectBehavior.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.codedx;
+
+public enum BuildEffectBehavior {
+	MarkFailed("Mark Failed"),
+	MarkUnstable("Mark Unstable"),
+	None("Ignore");
+
+	private String label;
+	BuildEffectBehavior(String label) {
+		this.label = label;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/codedx/CodeDxPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codedx/CodeDxPublisher.java
@@ -438,9 +438,7 @@ public class CodeDxPublisher extends Recorder implements SimpleBuildStep {
 					do {
 						Thread.sleep(3000);
 						oldStatus = status;
-						if(response != null) {
-							status = repeatingClient.getJobStatus(response.getJobId());
-						}
+						status = repeatingClient.getJobStatus(response.getJobId());
 						if (status != null && !status.equals(oldStatus)) {
 							if (Job.QUEUED.equals(status)) {
 								buildOutput.println("Code Dx analysis is queued");

--- a/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
@@ -59,11 +59,11 @@
 							 checked="${analysisResultConfiguration != null}"
 							 help="/plugin/codedx/help-analysisResultConfiguration.html">
 
-				<f:section title="Build Failure Conditions">
-					<f:entry title="'Break the build' Policy Action" field="breakForPolicy" help="/plugin/codedx/help-breakForPolicy.html">
-						<f:checkbox checked="${analysisResultConfiguration.breakForPolicy}" default="true"/>
-					</f:entry>
+				<f:entry title="'Break the build' Policy Action" field="policyBreakBuildBehavior" help="/plugin/codedx/help-policyBreakBuildBehavior.html">
+					<f:select default="MarkFailed" value="${analysisResultConfiguration.policyBreakBuildBehavior}" />
+				</f:entry>
 
+				<f:section title="Build Failure Conditions">
 					<f:entry title="Severity" field="failureSeverity" help="/plugin/codedx/help-failureSeverity.html">
 						<f:select value="${analysisResultConfiguration.failureSeverity}"/>
 					</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
@@ -47,18 +47,17 @@
 		<f:textbox/>
 	</f:entry>
 
+	<f:entry title="Error Handling" field="errorHandlingBehavior" help="/plugin/codedx/help-errorHandlingBehavior.html">
+		<!-- note: we could use <enum> instead, but it looks like this is semi-broken and unreliable (depending on jenkins version) -->
+		<f:select default="MarkFailed" />
+	</f:entry>
+
 	<f:block>
 		<table id="analysisResultConfiguration">
 			<j:set var="analysisResultConfiguration" value="${instance.analysisResultConfiguration}"/>
 			<f:optionalBlock title="Wait for Analysis Results" name="analysisResultConfiguration"
 							 checked="${analysisResultConfiguration != null}"
 							 help="/plugin/codedx/help-analysisResultConfiguration.html">
-
-				<f:section title="Error Handling">
-					<f:entry title="Analysis Error Behavior" field="analysisFailedBehavior">
-						<f:select default="None" />
-					</f:entry>
-				</f:section>
 
 				<f:section title="Build Failure Conditions">
 					<f:entry title="'Break the build' Policy Action" field="breakForPolicy" help="/plugin/codedx/help-breakForPolicy.html">

--- a/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codedx/CodeDxPublisher/config.jelly
@@ -54,11 +54,13 @@
 							 checked="${analysisResultConfiguration != null}"
 							 help="/plugin/codedx/help-analysisResultConfiguration.html">
 
-				<f:section title="Build Failure Conditions">
-					<f:entry title="Analysis Error" field="breakIfFailed" help="/plugin/codedx/help-breakIfFailed.html">
-						<f:checkbox checked="${analysisResultConfiguration.breakIfFailed}" default="true"/>
+				<f:section title="Error Handling">
+					<f:entry title="Analysis Error Behavior" field="analysisFailedBehavior">
+						<f:select default="None" />
 					</f:entry>
+				</f:section>
 
+				<f:section title="Build Failure Conditions">
 					<f:entry title="'Break the build' Policy Action" field="breakForPolicy" help="/plugin/codedx/help-breakForPolicy.html">
 						<f:checkbox checked="${analysisResultConfiguration.breakForPolicy}" default="true"/>
 					</f:entry>

--- a/src/main/webapp/help-breakIfFailed.html
+++ b/src/main/webapp/help-breakIfFailed.html
@@ -1,4 +1,0 @@
-<div>
-	<p>Whether or not to fail the build if the Code Dx analysis fails.</p>
-	<p>Note: connection errors such as timeouts will cause the build to fail regardless of this setting.</p>
-</div>

--- a/src/main/webapp/help-errorHandlingBehavior.html
+++ b/src/main/webapp/help-errorHandlingBehavior.html
@@ -1,0 +1,12 @@
+<div>
+	<p>
+		Determines the action when a connection error occurs, or when the analysis fails. If
+		set to "Ignore Errors", the build will always succeed when an error occurs, regardless
+		of any "Build Failure Conditions" or "Build Unstable Conditions" set in the
+		"Wait for Analysis Results" section.
+	</p>
+	<p>
+		(Does not affect behavior for internal plugin errors, eg configuration errors or unexpected exceptions - these
+		will still cause build errors.)
+	</p>
+</div>

--- a/src/main/webapp/help-errorHandlingBehavior.html
+++ b/src/main/webapp/help-errorHandlingBehavior.html
@@ -1,9 +1,11 @@
 <div>
 	<p>
-		Determines the action when a connection error occurs, or when the analysis fails. If
-		set to "Ignore Errors", the build will always succeed when an error occurs, regardless
-		of any "Build Failure Conditions" or "Build Unstable Conditions" set in the
-		"Wait for Analysis Results" section.
+		Determines the action when a Code Dx error occurs, such as connection issues or analysis failure (if "Wait for
+		Analysis Results" is enabled).
+	</p>
+	<p>
+		If set to "Ignore Errors", the build will always succeed when an error occurs, regardless
+		of any unstable/failure conditions set in the "Wait for Analysis Results" section.
 	</p>
 	<p>
 		(Does not affect behavior for internal plugin errors, eg configuration errors or unexpected exceptions - these

--- a/src/main/webapp/help-policyBreakBuildBehavior.html
+++ b/src/main/webapp/help-policyBreakBuildBehavior.html
@@ -4,6 +4,12 @@
 		its action set to "Break build".
 	</p>
 	<p>
+		A policy is only violated if one of its rules is matched and the finding age exceeds the "fix by"
+		field of the policy rule. If a new finding is introduced which violates a policy rule, but that
+		rule has its "fix by" set to anything other than "Not required", the build will not be
+		affected until a finding meets the required age.
+	</p>
+	<p>
 		(Note: policies are supported in Code Dx 2023.1.0 and up. This option will be ignored if using an older Code Dx version.)
 	</p>
 </div>

--- a/src/main/webapp/help-policyBreakBuildBehavior.html
+++ b/src/main/webapp/help-policyBreakBuildBehavior.html
@@ -1,7 +1,7 @@
 <div>
 	<p>
-		If enabled, will consider the build a failure if at least one of the Code Dx project's violated policies has
-		its action set to "Break the build".
+		Determines the build result if at least one of the Code Dx project's violated policies has
+		its action set to "Break build".
 	</p>
 	<p>
 		(Note: policies are supported in Code Dx 2023.1.0 and up. This option will be ignored if using an older Code Dx version.)


### PR DESCRIPTION
Changes implementation for error handling to allow more customization of behavior if a Code Dx error (eg connection failure, analysis failure) occurs.

"Internal" errors such as configuration issues will still be thrown and cause the plugin to break the build.

Also adds a bit more customization on behavior for violated policies.